### PR TITLE
Fixed formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,61 +7,28 @@ Package license: MIT
 
 Feedstock license: BSD 3-Clause
 
+[![pypi](https://img.shields.io/pypi/v/mlconjug.svg)](https://pypi.python.org/pypi/mlconjug)    [![travis](https://img.shields.io/travis/SekouD/mlconjug.svg)](https://travis-ci.org/SekouD/mlconjug)   [![appveyor](https://ci.appveyor.com/api/projects/status/6iatj101xxfehbo8/branch/master?svg=true)](https://ci.appveyor.com/project/SekouD/mlconjug) [![readthedocs](https://readthedocs.org/projects/mlconjug/badge/?version=latest)](https://mlconjug.readthedocs.io/en/latest/?badge=latest)  [![pyup](https://pyup.io/repos/github/SekouD/mlconjug/shield.svg)](https://pyup.io/repos/github/SekouD/mlconjug/)   [![codecov](https://codecov.io/gh/SekouD/mlconjug/branch/master/graph/badge.svg)](https://codecov.io/gh/SekouD/mlconjug)    [![snyk](https://snyk.io/test/github/SekouD/mlconjug/badge.svg?targetFile=requirements.txt)](https://snyk.io/test/github/SekouD/mlconjug?targetFile=requirements.txt)
+
 Summary: A Python library to conjugate French, English, Spanish, Italian, Portuguese and Romanian verbs using Machine Learning techniques.
 
-.. image:: https://raw.githubusercontent.com/SekouD/mlconjug/master/logo/logotype2%20mlconjug.png
-        :target: https://pypi.python.org/pypi/mlconjug
-        :alt: mlconjug PyPi Home Page
 
-========
-mlconjug
-========
+Any verb in one of the supported language can be conjugated, as the module contains a Machine Learning model of how the verbs behave.
 
+Even completely new or made-up verbs can be successfully conjugated in this manner.
 
-.. image:: https://img.shields.io/pypi/v/mlconjug.svg
-        :target: https://pypi.python.org/pypi/mlconjug
-        :alt: Pypi Python Package Index Status
-
-.. image:: https://img.shields.io/travis/SekouD/mlconjug.svg
-        :target: https://travis-ci.org/SekouD/mlconjug
-        :alt: Linux Continuous Integration Status
-
-.. image:: https://ci.appveyor.com/api/projects/status/6iatj101xxfehbo8/branch/master?svg=true
-        :target: https://ci.appveyor.com/project/SekouD/mlconjug
-        :alt: Windows Continuous Integration Status
-
-.. image:: https://readthedocs.org/projects/mlconjug/badge/?version=latest
-        :target: https://mlconjug.readthedocs.io/en/latest/?badge=latest
-        :alt: Documentation Status
-
-.. image:: https://pyup.io/repos/github/SekouD/mlconjug/shield.svg
-        :target: https://pyup.io/repos/github/SekouD/mlconjug/
-        :alt: Depedencies Update Status
-
-.. image:: https://codecov.io/gh/SekouD/mlconjug/branch/master/graph/badge.svg
-        :target: https://codecov.io/gh/SekouD/mlconjug
-        :alt: Code Coverage Status
-
-.. image:: https://snyk.io/test/github/SekouD/mlconjug/badge.svg?targetFile=requirements.txt
-        :target: https://snyk.io/test/github/SekouD/mlconjug?targetFile=requirements.txt
-        :alt: Code Vulnerability Status
-
-
-| A Python library to conjugate verbs in French, English, Spanish, Italian, Portuguese and Romanian (more soon)
-    using Machine Learning techniques.
-| Any verb in one of the supported language can be conjugated, as the module contains a Machine Learning model of how the verbs behave.
-| Even completely new or made-up verbs can be successfully conjugated in this manner.
-| The supplied pre-trained models are composed of:
+The supplied pre-trained models are composed of:
 
 - a binary feature extractor,
 - a feature selector using Linear Support Vector Classification,
 - a classifier using Stochastic Gradient Descent.
 
-| MLConjug uses scikit-learn to implement the Machine Learning algorithms.
-| Users of the library can use any compatible classifiers from scikit-learn to modify and retrain the models.
+MLConjug uses scikit-learn to implement the Machine Learning algorithms.
 
-| The training data for the french model is based on Verbiste https://perso.b2b2c.ca/~sarrazip/dev/verbiste.html .
-| The training data for English, Spanish, Italian, Portuguese and Romanian was generated using unsupervised learning techniques
+Users of the library can use any compatible classifiers from scikit-learn to modify and retrain the models.
+
+The training data for the french model is based on Verbiste https://perso.b2b2c.ca/~sarrazip/dev/verbiste.html .
+
+The training data for English, Spanish, Italian, Portuguese and Romanian was generated using unsupervised learning techniques
   using the French model as a model to query during the training.
 
 
@@ -91,18 +58,10 @@ Features
 Credits
 ---------
 
-This package was created with the help of Verbiste_ and scikit-learn_.
+This package was created with the help of [Verbiste](https://perso.b2b2c
+.ca/~sarrazip/dev/verbiste.html) and [scikit-learn](http://scikit-learn.org/stable/index.html).
 
-The logo was designed by Zuur_.
-
-.. _Verbiste: https://perso.b2b2c.ca/~sarrazip/dev/verbiste.html
-.. _scikit-learn: http://scikit-learn.org/stable/index.html
-.. _Zuur: https://github.com/zuuritaly
-
-
-
-
-
+The logo was designed by [Zuur](https://github.com/zuuritaly).
 
 
 


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
I fixed the few formatting errors due to rst to md conversion of the README file.

Checklist
* [x] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
